### PR TITLE
Units and movement

### DIFF
--- a/Assets/Materials/Unit Material.mat
+++ b/Assets/Materials/Unit Material.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Unit Material
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 0, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/Unit Material.mat.meta
+++ b/Assets/Materials/Unit Material.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 540ecc6de8d287a4da70c0b257ca185b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Unit.prefab
+++ b/Assets/Prefabs/Unit.prefab
@@ -1,0 +1,141 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &191344338337699699
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2138022896709042380}
+  - component: {fileID: 2992501328047462655}
+  m_Layer: 0
+  m_Name: Unit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2138022896709042380
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191344338337699699}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1154882177765600532}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2992501328047462655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191344338337699699}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70d891e7eec0fc341a596826eb5f50ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1382874570434618626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1154882177765600532}
+  - component: {fileID: 6857110165319508623}
+  - component: {fileID: 4759854223907581482}
+  - component: {fileID: 3697780828449875565}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1154882177765600532
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382874570434618626}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 0}
+  m_LocalScale: {x: 3, y: 10, z: 3}
+  m_Children: []
+  m_Father: {fileID: 2138022896709042380}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6857110165319508623
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382874570434618626}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4759854223907581482
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382874570434618626}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 540ecc6de8d287a4da70c0b257ca185b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3697780828449875565
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1382874570434618626}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Unit.prefab.meta
+++ b/Assets/Prefabs/Unit.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 04226d275e5cdaf45a23488b100751c3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -7269,6 +7269,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   hexGrid: {fileID: 1477363576}
   terrainMaterial: {fileID: 2100000, guid: a25323038594e2847a6ab2981822bee3, type: 2}
+  unitPrefab: {fileID: 2992501328047462655, guid: 04226d275e5cdaf45a23488b100751c3, type: 3}
 --- !u!114 &999126125
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -283,6 +283,7 @@ Transform:
   m_LocalPosition: {x: 1254.3096, y: 661.3876, z: -36.1532}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1630187186}
   - {fileID: 999126128}
   - {fileID: 1365978203}
   - {fileID: 877647281}
@@ -2636,6 +2637,18 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 999126124}
         m_TargetAssemblyTypeName: HexMapEditor, Assembly-CSharp
+        m_MethodName: SetEditMode
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 1
+      - m_Target: {fileID: 1630187187}
+        m_TargetAssemblyTypeName: HexGameUI, Assembly-CSharp
         m_MethodName: SetEditMode
         m_Mode: 0
         m_Arguments:
@@ -6148,7 +6161,7 @@ RectTransform:
   - {fileID: 1110503193}
   - {fileID: 457287971}
   m_Father: {fileID: 34305408}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -7262,14 +7275,13 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 999126123}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0f9189304915e6c4ea244da13b695751, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   hexGrid: {fileID: 1477363576}
   terrainMaterial: {fileID: 2100000, guid: a25323038594e2847a6ab2981822bee3, type: 2}
-  unitPrefab: {fileID: 2992501328047462655, guid: 04226d275e5cdaf45a23488b100751c3, type: 3}
 --- !u!114 &999126125
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7344,7 +7356,7 @@ RectTransform:
   - {fileID: 1827183967}
   - {fileID: 312642351}
   m_Father: {fileID: 34305408}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -9199,7 +9211,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 34305408}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1261496346
 GameObject:
@@ -10131,7 +10143,7 @@ RectTransform:
   - {fileID: 289410050}
   - {fileID: 265324127}
   m_Father: {fileID: 34305408}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -10906,12 +10918,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: df9db2fb1d0e0c94880a67b29cf9660b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cellCountX: 20
+  cellCountZ: 15
   cellPrefab: {fileID: 1032167773982137314, guid: 8029e731a05bc3b40a786cffdce8381e, type: 3}
   cellLabelPrefab: {fileID: 3333104567422867804, guid: 4f2d400c923f0f84798bbe9e40026c1a, type: 3}
   chunkPrefab: {fileID: 6158056574623472290, guid: c59a941f4a223fe49b3ecb931cc80bcb, type: 3}
+  unitPrefab: {fileID: 2992501328047462655, guid: 04226d275e5cdaf45a23488b100751c3, type: 3}
   noiseSource: {fileID: 2800000, guid: fe5af6a815d34b54d808455fcc9371ba, type: 3}
-  cellCountX: 20
-  cellCountZ: 15
   seed: 0
 --- !u!4 &1477363577
 Transform:
@@ -12144,6 +12157,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1590925240}
   m_CullTransparentMesh: 0
+--- !u!1 &1630187185
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1630187186}
+  - component: {fileID: 1630187187}
+  m_Layer: 0
+  m_Name: Game UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1630187186
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1630187185}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 34305408}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1630187187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1630187185}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90571216f97b2f840996e2e22bc33dda, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  grid: {fileID: 1477363576}
 --- !u!1 &1661366563
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Bezier.cs
+++ b/Assets/Scripts/Bezier.cs
@@ -1,0 +1,33 @@
+﻿using UnityEngine;
+
+public static class Bezier
+{
+	/// <summary>
+	/// Gets a point on a quadratic Bezier curve:
+	/// (1−t)^2 A +2 * (1−t) * t * B + t^2 * C
+	/// </summary>
+	/// <param name="a">Control point A</param>
+	/// <param name="b">Control point B</param>
+	/// <param name="c">Control point C</param>
+	/// <param name="t">Interpolator</param>
+	/// <returns></returns>
+	public static Vector3 GetPoint(Vector3 a, Vector3 b, Vector3 c, float t)
+	{
+		float r = 1f - t;
+		return r * r * a + 2f * r * t * b + t * t * c;
+	}
+
+	/// <summary>
+	/// Gets the derivative of a point on a Bezier curve.
+	/// Derivative vector corresponds with the travel direction along the curve.
+	/// </summary>
+	/// <param name="a">Control point A</param>
+	/// <param name="b">Control point B</param>
+	/// <param name="c">Control point C</param>
+	/// <param name="t">Interpolator. Must not be zero!</param>
+	/// <returns></returns>
+	public static Vector3 GetDerivative(Vector3 a, Vector3 b, Vector3 c, float t)
+	{
+		return 2f * ((1f - t) * (b - a) + t * (c - b));
+	}
+}

--- a/Assets/Scripts/Bezier.cs.meta
+++ b/Assets/Scripts/Bezier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76161af466279f5429e65afc13c31058
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/HexCell.cs
+++ b/Assets/Scripts/HexCell.cs
@@ -337,14 +337,21 @@ public class HexCell : MonoBehaviour
 		set
 		{
 			distance = value;
-			UpdateDistanceLabel();
 		}
 	}
 
-	void UpdateDistanceLabel()
+	/// <summary>
+	/// Indicates the part of the search phase this cell is in.
+	/// A value of 0 indicates that the cell has not yet been visited.
+	/// A value of 1 indicates that the cell is currently part of the search frontier.
+	/// A value of 2 indicates that the cell has already been taken out of the frontier.
+	/// </summary>
+	public int SearchPhase { get; set; }
+
+	public void SetLabel(string text)
 	{
 		Text label = UiRect.GetComponent<Text>();
-		label.text = distance == int.MaxValue ? "" : distance.ToString();
+		label.text = text;
 	}
 
 	public void DisableHighlight()

--- a/Assets/Scripts/HexCell.cs
+++ b/Assets/Scripts/HexCell.cs
@@ -48,6 +48,11 @@ public class HexCell : MonoBehaviour
 	/// </summary>
 	public HexCell NextWithSamePriority { get; set; }
 
+	/// <summary>
+	/// A reference to the unit that is currently occupying the cell.
+	/// </summary>
+	public HexUnit Unit { get; set; }
+
 	public int SearchPriority
 	{
 		get
@@ -552,11 +557,21 @@ public class HexCell : MonoBehaviour
 				}
 			}
 		}
+
+		if (Unit)
+		{
+			Unit.ValidateLocation();
+		}
 	}
 
 	void RefreshSelfOnly()
 	{
 		chunk.Refresh();
+
+		if (Unit)
+		{
+			Unit.ValidateLocation();
+		}
 	}
 
 	public void Save(BinaryWriter writer)

--- a/Assets/Scripts/HexCoordinates.cs
+++ b/Assets/Scripts/HexCoordinates.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.IO;
+using UnityEngine;
 
 [System.Serializable]
 public struct HexCoordinates
@@ -89,5 +90,19 @@ public struct HexCoordinates
 	public string ToStringOnSeparateLines()
 	{
 		return X.ToString() + "\n" + Y.ToString() + "\n" + Z.ToString();
+	}
+
+	public void Save(BinaryWriter writer)
+	{
+		writer.Write(x);
+		writer.Write(z);
+	}
+
+	public static HexCoordinates Load(BinaryReader reader)
+	{
+		HexCoordinates c;
+		c.x = reader.ReadInt32();
+		c.z = reader.ReadInt32();
+		return c;
 	}
 }

--- a/Assets/Scripts/HexGrid.cs
+++ b/Assets/Scripts/HexGrid.cs
@@ -29,6 +29,10 @@ public class HexGrid : MonoBehaviour
 	private int chunkCountZ;
 
 	private HexCellPriorityQueue searchFrontier;
+	private int searchFrontierPhase;
+	private HexCell currentPathFrom;
+	private HexCell currentPathTo;
+	private bool currentPathExists;
 
 	void Awake()
 	{
@@ -56,6 +60,7 @@ public class HexGrid : MonoBehaviour
 			return false;
 		}
 
+		ClearPath();
 		if (chunks != null)
 		{
 			for (int i = 0; i < chunks.Length; i++)
@@ -189,14 +194,82 @@ public class HexGrid : MonoBehaviour
 		return cells[x + z * cellCountX];
 	}
 
-	public void FindPath(HexCell fromCell, HexCell toCell)
+	/// <summary>
+	/// Initiates a search for the shortest path between two cells.
+	/// </summary>
+	/// <param name="fromCell">The starting cell</param>
+	/// <param name="toCell">The destination cell</param>
+	/// <param name="speed">The unit's movement speed. Since the default movement cost is 5, a number *not* divisible by 5 should be preferred.</param>
+	public void FindPath(HexCell fromCell, HexCell toCell, int speed)
 	{
-		StopAllCoroutines();
-		StartCoroutine(Search(fromCell, toCell));
+		ClearPath();
+		currentPathFrom = fromCell;
+		currentPathTo = toCell;
+		currentPathExists = Search(fromCell, toCell, speed);
+		if (currentPathExists)
+		{
+			ShowPath(speed);
+		}
 	}
 
-	IEnumerator Search(HexCell fromCell, HexCell toCell)
+	/// <summary>
+	/// Reconstruct the shortest path by stepping through it backwards.
+	/// Shows labels along the path, displaying the required turns
+	/// </summary>
+	/// <param name="speed">The movement speed of the unit</param>
+	void ShowPath(int speed)
 	{
+		if (currentPathExists)
+		{
+			HexCell current = currentPathTo;
+			while (current != currentPathFrom)
+			{
+				int turn = current.Distance / speed;
+				current.SetLabel(turn.ToString());
+				current.EnableHighlight(Color.white);
+				current = current.PathFrom;
+			}
+		}
+		currentPathFrom.EnableHighlight(Color.blue);
+		currentPathTo.EnableHighlight(Color.red);
+	}
+
+	void ClearPath()
+	{
+		if (currentPathExists)
+		{
+			HexCell current = currentPathTo;
+			while (current != currentPathFrom)
+			{
+				current.SetLabel(null);
+				current.DisableHighlight();
+				current = current.PathFrom;
+			}
+			current.DisableHighlight();
+			currentPathExists = false;
+		}
+		else if (currentPathFrom)
+		{
+			currentPathFrom.DisableHighlight();
+			currentPathTo.DisableHighlight();
+		}
+		currentPathFrom = currentPathTo = null;
+	}
+
+	/// <summary>
+	/// Searches for the optimal (shortest) path between two cells. Uses the A* algorithm
+	/// for pathfinding, taking into account varying movement costs depending on terrain.
+	/// Displays the number of turns required along the found path.
+	/// </summary>
+	/// <param name="fromCell">The starting cell</param>
+	/// <param name="toCell">The destination cell</param>
+	/// <param name="speed">The unit's movement speed. Since the default movement cost is 5, a number *not* divisible by 5 should be preferred.</param>
+	/// <returns>Success or failure</returns>
+	bool Search(HexCell fromCell, HexCell toCell, int speed)
+	{
+		// Ensure that new search frontier is always larger than the previous one
+		searchFrontierPhase += 2;
+
 		if (searchFrontier == null)
 		{
 			searchFrontier = new HexCellPriorityQueue();
@@ -206,40 +279,31 @@ public class HexGrid : MonoBehaviour
 			searchFrontier.Clear();
 		}
 
-		// int.MaxValue indicates that a cell hasn't been visited yet.
-		for (int i = 0; i < cells.Length; i++)
-		{
-			cells[i].Distance = int.MaxValue;
-			cells[i].DisableHighlight();
-		}
-		fromCell.EnableHighlight(Color.blue);
-		toCell.EnableHighlight(Color.red);
-
-		WaitForSeconds delay = new WaitForSeconds(1 / 60f);
+		fromCell.SearchPhase = searchFrontierPhase;
 		fromCell.Distance = 0;
 		searchFrontier.Enqueue(fromCell);
 
 		while (searchFrontier.Count > 0)
 		{
-			yield return delay;
+			// Cells taken out of the frontier will have a larger phase than the existing 
+			// frontier, but smaller than the fontier of the next search will have.
 			HexCell current = searchFrontier.Dequeue();
+			current.SearchPhase += 1;
 
 			if (current == toCell)
 			{
-				current = current.PathFrom;
-				while (current != fromCell)
-				{
-					current.EnableHighlight(Color.white);
-					current = current.PathFrom;
-				}
-				break;
+				// Found the shortest path
+				return true;
 			}
+
+			int currentTurn = current.Distance / speed;
 
 			for (HexDirection d = HexDirection.NE; d <= HexDirection.NW; d++)
 			{
 				HexCell neighbor = current.GetNeighbor(d);
 
-				if (neighbor == null)
+				// Cells that were already taken out of the frontier will be skipped
+				if (neighbor == null || neighbor.SearchPhase > searchFrontierPhase)
 				{
 					continue;
 				}
@@ -253,10 +317,10 @@ public class HexGrid : MonoBehaviour
 					continue;
 				}
 
-				int distance = current.Distance;
+				int moveCost;
 				if (current.HasRoadThroughEdge(d))
 				{
-					distance += 1;
+					moveCost = 1;
 				}
 				else if (current.Walled != neighbor.Walled)
 				{
@@ -264,14 +328,24 @@ public class HexGrid : MonoBehaviour
 				}
 				else
 				{
-					distance += edgeType == HexEdgeType.Flat ? 5 : 10;
+					moveCost = edgeType == HexEdgeType.Flat ? 5 : 10;
 
 					// Features without roads slow down movement.
-					distance += neighbor.UrbanLevel + neighbor.FarmLevel + neighbor.PlantLevel;
+					moveCost += neighbor.UrbanLevel + neighbor.FarmLevel + neighbor.PlantLevel;
 				}
 
-				if (neighbor.Distance == int.MaxValue)
+				// This will discard leftover movement points and add them to the total distance.
+				// The most efficient path will waste as few points as possible.
+				int distance = current.Distance + moveCost;
+				int turn = distance / speed;
+				if (turn > currentTurn)
 				{
+					distance = turn * speed + moveCost;
+				}
+
+				if (neighbor.SearchPhase < searchFrontierPhase)
+				{
+					neighbor.SearchPhase = searchFrontierPhase;
 					neighbor.Distance = distance;
 					neighbor.PathFrom = current;
 					neighbor.SearchHeuristic = neighbor.coordinates.DistanceTo(toCell.coordinates);
@@ -286,6 +360,8 @@ public class HexGrid : MonoBehaviour
 				}
 			}
 		}
+
+		return false;
 	}
 
 	public void Save(BinaryWriter writer)
@@ -301,8 +377,7 @@ public class HexGrid : MonoBehaviour
 
 	public void Load(BinaryReader reader, int header)
 	{
-		StopAllCoroutines();
-
+		ClearPath();
 		int x = 20, z = 15;
 		if (header >= 1)
 		{

--- a/Assets/Scripts/HexMapEditor.cs
+++ b/Assets/Scripts/HexMapEditor.cs
@@ -92,21 +92,28 @@ public class HexMapEditor : MonoBehaviour
 			}
 			else if (Input.GetKey(KeyCode.LeftShift) && searchToCell != currentCell)
 			{
-				if (searchFromCell)
+				if (searchFromCell != currentCell)
 				{
-					searchFromCell.DisableHighlight();
-				}
-				searchFromCell = currentCell;
-				searchFromCell.EnableHighlight(Color.blue);
+					if (searchFromCell)
+					{
+						searchFromCell.DisableHighlight();
+					}
+					searchFromCell = currentCell;
+					searchFromCell.EnableHighlight(Color.blue);
 
-				if (searchToCell)
-				{
-					hexGrid.FindPath(searchFromCell, searchToCell);
+					if (searchToCell)
+					{
+						hexGrid.FindPath(searchFromCell, searchToCell, 24);
+					}
 				}
 			}
 			else if (searchFromCell && searchFromCell != currentCell)
 			{
-				hexGrid.FindPath(searchFromCell, currentCell);
+				if (searchToCell != currentCell)
+				{
+					searchToCell = currentCell;
+					hexGrid.FindPath(searchFromCell, searchToCell, 24);
+				}
 			}
 
 			previousCell = currentCell;

--- a/Assets/Scripts/HexMapEditor.cs
+++ b/Assets/Scripts/HexMapEditor.cs
@@ -18,6 +18,9 @@ public class HexMapEditor : MonoBehaviour
 	[SerializeField]
 	Material terrainMaterial = default;
 
+	[SerializeField]
+	HexUnit unitPrefab = default;
+
 	private bool editMode;
 	private int activeTerrainTypeIndex;
 	private bool applyElevation = true;
@@ -60,23 +63,34 @@ public class HexMapEditor : MonoBehaviour
 
 	void Update()
 	{
-		if (Input.GetMouseButton(0) && !EventSystem.current.IsPointerOverGameObject())
+		if (!EventSystem.current.IsPointerOverGameObject())
 		{
-			HandleInput();
+			if (Input.GetMouseButton(0))
+			{
+				HandleInput();
+				return;
+			}
+			if (Input.GetKeyDown(KeyCode.U))
+			{
+				if (Input.GetKey(KeyCode.LeftShift))
+				{
+					DestroyUnit();
+				}
+				else
+				{
+					CreateUnit();
+				}
+				return;
+			}
 		}
-		else
-		{
-			previousCell = null;
-		}
+		previousCell = null;
 	}
 
 	void HandleInput()
 	{
-		Ray inputRay = Camera.main.ScreenPointToRay(Input.mousePosition);
-		RaycastHit hit;
-		if (Physics.Raycast(inputRay, out hit))
+		HexCell currentCell = GetCellUnderCursor();
+		if (currentCell)
 		{
-			HexCell currentCell = hexGrid.GetCell(hit.point);
 			if (previousCell && previousCell != currentCell)
 			{
 				ValidateDrag(currentCell);
@@ -122,6 +136,17 @@ public class HexMapEditor : MonoBehaviour
 		{
 			previousCell = null;
 		}
+	}
+
+	HexCell GetCellUnderCursor()
+	{
+		Ray inputRay = Camera.main.ScreenPointToRay(Input.mousePosition);
+		RaycastHit hit;
+		if (Physics.Raycast(inputRay, out hit))
+		{
+			return hexGrid.GetCell(hit.point);
+		}
+		return null;
 	}
 
 	void ValidateDrag(HexCell currentCell)
@@ -322,6 +347,27 @@ public class HexMapEditor : MonoBehaviour
 					}
 				}
 			}
+		}
+	}
+
+	void CreateUnit()
+	{
+		HexCell cell = GetCellUnderCursor();
+		if (cell && !cell.Unit)
+		{
+			HexUnit unit = Instantiate(unitPrefab);
+			unit.transform.SetParent(hexGrid.transform, false);
+			unit.Location = cell;
+			unit.Orientation = Random.Range(0f, 360f);
+		}
+	}
+
+	void DestroyUnit()
+	{
+		HexCell cell = GetCellUnderCursor();
+		if (cell && cell.Unit)
+		{
+			cell.Unit.Die();
 		}
 	}
 }

--- a/Assets/Scripts/HexUnit.cs
+++ b/Assets/Scripts/HexUnit.cs
@@ -1,0 +1,45 @@
+﻿using UnityEngine;
+
+public class HexUnit : MonoBehaviour
+{
+	public HexCell Location
+	{
+		get
+		{
+			return location;
+		}
+		set
+		{
+			location = value;
+			value.Unit = this;
+			transform.localPosition = value.Position;
+		}
+	}
+
+	public float Orientation
+	{
+		get
+		{
+			return orientation;
+		}
+		set
+		{
+			orientation = value;
+			transform.localRotation = Quaternion.Euler(0f, value, 0f);
+		}
+	}
+
+	private float orientation;
+	private HexCell location;
+
+	public void ValidateLocation()
+	{
+		transform.localPosition = location.Position;
+	}
+
+	public void Die()
+	{
+		location.Unit = null;
+		Destroy(gameObject);
+	}
+}

--- a/Assets/Scripts/HexUnit.cs
+++ b/Assets/Scripts/HexUnit.cs
@@ -1,7 +1,17 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
 
 public class HexUnit : MonoBehaviour
 {
+	const float travelSpeed = 4f;
+	const float rotationSpeed = 180f;
+
+	public static HexUnit unitPrefab;
+
+	private List<HexCell> pathToTravel;
+
 	public HexCell Location
 	{
 		get
@@ -10,6 +20,10 @@ public class HexUnit : MonoBehaviour
 		}
 		set
 		{
+			if (location)
+			{
+				location.Unit = null;
+			}
 			location = value;
 			value.Unit = this;
 			transform.localPosition = value.Position;
@@ -32,14 +46,120 @@ public class HexUnit : MonoBehaviour
 	private float orientation;
 	private HexCell location;
 
+	void OnEnable()
+	{
+		if (location)
+		{
+			transform.localPosition = location.Position;
+		}
+	}
+
 	public void ValidateLocation()
 	{
 		transform.localPosition = location.Position;
+	}
+
+	/// <summary>
+	/// Validates a move order. For now, this blocks movement to underwater 
+	/// cells and cells occupied by another unit. The rules for this will
+	/// most likely change with the introduction of certain unit types (e.g. 
+	/// flying, aquatic, or amphibious units.
+	/// </summary>
+	/// <param name="cell">The destination cell</param>
+	/// <returns>Validity</returns>
+	public bool IsValidDestination(HexCell cell)
+	{
+		return !cell.IsUnderwater && !cell.Unit;
 	}
 
 	public void Die()
 	{
 		location.Unit = null;
 		Destroy(gameObject);
+	}
+
+	public void Travel(List<HexCell> path)
+	{
+		Location = path[path.Count - 1];
+		pathToTravel = path;
+		StopAllCoroutines();
+		StartCoroutine(TravelPath());
+	}
+
+	IEnumerator TravelPath()
+	{
+		Vector3 a, b, c = pathToTravel[0].Position;
+		transform.localPosition = c;
+		yield return LookAt(pathToTravel[1].Position);
+
+		float t = Time.deltaTime * travelSpeed;		// Don't wait for next frame, start moving immediately
+		for (int i = 1; i < pathToTravel.Count; i++)
+		{
+			a = c;
+			b = pathToTravel[i - 1].Position;
+			c = (b + pathToTravel[i].Position) * 0.5f;
+			for (; t < 1f; t += Time.deltaTime * travelSpeed)
+			{
+				transform.localPosition = Bezier.GetPoint(a, b, c, t);
+				Vector3 d = Bezier.GetDerivative(a, b, c, t);
+				d.y = 0f;
+				transform.localRotation = Quaternion.LookRotation(d);
+				yield return null;
+			}
+			t -= 1f;
+		}
+
+		a = c;
+		b = pathToTravel[pathToTravel.Count - 1].Position;
+		c = b;
+		for (; t < 1f; t += Time.deltaTime * travelSpeed)
+		{
+			transform.localPosition = Bezier.GetPoint(a, b, c, t);
+			Vector3 d = Bezier.GetDerivative(a, b, c, t);
+			d.y = 0f;
+			transform.localRotation = Quaternion.LookRotation(d);
+			yield return null;
+		}
+
+		transform.localPosition = location.Position;
+		orientation = transform.localRotation.eulerAngles.y;
+
+		ListPool<HexCell>.Add(pathToTravel);
+		pathToTravel = null;
+	}
+
+	IEnumerator LookAt(Vector3 point)
+	{
+		point.y = transform.localPosition.y;
+
+		Quaternion fromRotation = transform.localRotation;
+		Quaternion toRotation = Quaternion.LookRotation(point - transform.localPosition);
+		float angle = Quaternion.Angle(fromRotation, toRotation);
+
+		if (angle > 0f)
+		{
+			float speed = rotationSpeed / angle;
+			for (float t = Time.deltaTime * speed; t < 1f; t += Time.deltaTime * speed)
+			{
+				transform.localRotation = Quaternion.Slerp(fromRotation, toRotation, t);
+				yield return null;
+			}
+		}
+
+		transform.LookAt(point);
+		orientation = transform.localRotation.eulerAngles.y;
+	}
+
+	public void Save(BinaryWriter writer)
+	{
+		location.coordinates.Save(writer);
+		writer.Write(orientation);
+	}
+
+	public static void Load(BinaryReader reader, HexGrid grid)
+	{
+		HexCoordinates coordinates = HexCoordinates.Load(reader);
+		float orientation = reader.ReadSingle();
+		grid.AddUnit(Instantiate(unitPrefab), grid.GetCell(coordinates), orientation);
 	}
 }

--- a/Assets/Scripts/HexUnit.cs.meta
+++ b/Assets/Scripts/HexUnit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70d891e7eec0fc341a596826eb5f50ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/HexGameUI.cs
+++ b/Assets/Scripts/UI/HexGameUI.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class HexGameUI : MonoBehaviour
+{
+	[SerializeField]
+	HexGrid grid = default;
+
+	private HexCell currentCell;
+	private HexUnit selectedUnit;
+
+	void Update()
+	{
+		if (!EventSystem.current.IsPointerOverGameObject())
+		{
+			if (Input.GetMouseButtonDown(0))
+			{
+				DoSelection();
+			}
+			else if (selectedUnit)
+			{
+				if (Input.GetMouseButtonDown(1))
+				{
+					DoMove();
+				}
+				else
+				{
+					DoPathfinding();
+				}
+			}
+		}
+	}
+
+	public void SetEditMode(bool toggle)
+	{
+		grid.ClearPath();
+		selectedUnit = null;
+		enabled = !toggle;
+		grid.ShowUI(!toggle);
+	}
+
+	bool UpdateCurrentCell()
+	{
+		HexCell cell = grid.GetCell(Camera.main.ScreenPointToRay(Input.mousePosition));
+		if (cell != currentCell)
+		{
+			currentCell = cell;
+			return true;
+		}
+		return false;
+	}
+
+	void DoSelection()
+	{
+		grid.ClearPath();
+
+		UpdateCurrentCell();
+		if (currentCell)
+		{
+			selectedUnit = currentCell.Unit;
+		}
+	}
+
+	void DoPathfinding()
+	{
+		if (UpdateCurrentCell())
+		{
+			if (currentCell && selectedUnit.IsValidDestination(currentCell))
+			{
+				grid.FindPath(selectedUnit.Location, currentCell, 24);
+			}
+			else
+			{
+				grid.ClearPath();
+			}
+		}
+	}
+
+	void DoMove()
+	{
+		if (grid.HasPath)
+		{
+			selectedUnit.Travel(grid.GetPath());
+			grid.ClearPath();
+			selectedUnit = null;
+		}
+	}
+}

--- a/Assets/Scripts/UI/HexGameUI.cs.meta
+++ b/Assets/Scripts/UI/HexGameUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90571216f97b2f840996e2e22bc33dda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Units can now be added in Edit Mode. Only one unit can occupy a cell at any point in time.
* While not in Edit Mode, units can be selected with left click. Hovering over another cell will display a movement path and the turns required to reach it (currently using a fixed movement speed).
* With a unit selected, a right click will issue a movement order. The unit will move on a smooth curve along the shortest path towards the destination.