### PR TITLE
Enable/disable pathfinding into and through unexplored territory

### DIFF
--- a/Assets/Scripts/UI/HexGameUI.cs
+++ b/Assets/Scripts/UI/HexGameUI.cs
@@ -105,7 +105,7 @@ public class HexGameUI : MonoBehaviour
 		{
 			if (currentCell && selectedUnit.IsValidDestination(currentCell))
 			{
-				grid.FindPath(selectedUnit.Location, currentCell, selectedUnit.MovementPoints);
+				grid.FindPath(selectedUnit.Location, currentCell, selectedUnit);
 			}
 			else
 			{

--- a/Assets/Scripts/UI/HexTooltip.cs
+++ b/Assets/Scripts/UI/HexTooltip.cs
@@ -38,7 +38,7 @@ public class HexTooltip : MonoBehaviour
 
 		unitName.text = unit.Name;
 		unitHitpoints.text = "10";
-		unitMovement.text = unit.MovementPoints.ToString();
+		unitMovement.text = unit.Speed.ToString();
 		unitAttack.text = "10";
 		unitRange.text = "1";
 


### PR DESCRIPTION
This restricts movement orders to areas that are revealed on the map. While this is a valid option, it may not be ideal or desired.