### PR TITLE
Manual seeding

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1388,10 +1388,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 1948200432}
   m_HandleRect: {fileID: 1857219290}
   m_Direction: 0
-  m_MinValue: 0
-  m_MaxValue: 10
+  m_MinValue: -2
+  m_MaxValue: 8
   m_WholeNumbers: 1
-  m_Value: 0
+  m_Value: -0
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
@@ -3115,8 +3115,12 @@ MonoBehaviour:
   jitterProbability: 0.25
   chunkSizeMin: 30
   chunkSizeMax: 100
+  elevationMinimum: -2
+  elevationMaximum: 8
   waterLevel: 3
   landPercentage: 50
+  highRiseProbability: 0.25
+  sinkProbability: 0.2
 --- !u!4 &332663528
 Transform:
   m_ObjectHideFlags: 0
@@ -14910,8 +14914,8 @@ MonoBehaviour:
   m_FillRect: {fileID: 1311645577}
   m_HandleRect: {fileID: 462152025}
   m_Direction: 0
-  m_MinValue: 0
-  m_MaxValue: 6
+  m_MinValue: -2
+  m_MaxValue: 8
   m_WholeNumbers: 1
   m_Value: 0
   m_OnValueChanged:

--- a/Assets/Scripts/HexCell.cs
+++ b/Assets/Scripts/HexCell.cs
@@ -671,7 +671,7 @@ public class HexCell : MonoBehaviour
 	public void Save(BinaryWriter writer)
 	{
 		writer.Write((byte)terrainTypeIndex);
-		writer.Write((byte)elevation);
+		writer.Write((byte)(elevation + 127));
 		writer.Write((byte)waterLevel);
 		writer.Write((byte)urbanLevel);
 		writer.Write((byte)farmLevel);
@@ -716,6 +716,11 @@ public class HexCell : MonoBehaviour
 	{
 		TerrainTypeIndex = reader.ReadByte();
 		elevation = reader.ReadByte();
+		if (header >= 4)
+		{
+			elevation -= 127;
+		}
+
 		RefreshPosition();
 		waterLevel = reader.ReadByte();
 		urbanLevel = reader.ReadByte();

--- a/Assets/Scripts/HexGrid.cs
+++ b/Assets/Scripts/HexGrid.cs
@@ -109,7 +109,7 @@ public class HexGrid : MonoBehaviour
 		return true;
 	}
 
-		void CreateChunks()
+	void CreateChunks()
 	{
 		chunks = new HexGridChunk[chunkCountX * chunkCountZ];
 

--- a/Assets/Scripts/UI/SaveLoadMenu.cs
+++ b/Assets/Scripts/UI/SaveLoadMenu.cs
@@ -5,7 +5,7 @@ using System.IO;
 
 public class SaveLoadMenu : MonoBehaviour
 {
-	const int mapFileVersion = 3;
+	const int mapFileVersion = 4;
 
 	[SerializeField]
 	Text menuLabel = default;


### PR DESCRIPTION
Limited elevation and waterlevel to values between -2 and 8. Save file now stores elevation with a +127 bias to support negative numbers. Added support for storing RNG seed state. Added manual seeding.